### PR TITLE
fix: Add missing else condition in sigar_os_sys_info_get

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -19,7 +19,9 @@ IPv6 support on the official sigar-1.6 branch are incompatible with the Java wra
 We build patched Windows DLLs on a Windows Server 2016 10.0 node. The following tooling needs to be installed in order to build successfully:
 * Java 1.8 (we build using Azul Zulu 1.8)
 * Apache ant (we use Apache Ant(TM) version 1.10.11 compiled on July 10 2021)
-* Microsoft Visual Studio 2015 Community from [here](https://go.microsoft.com/fwlink/?LinkId=615448&clcid=0x409) (required for ATL headers)
+* git
+* Microsoft Visual Studio 2015 Community from [here](https://go.microsoft.com/fwlink/?LinkId=615448&clcid=0x409) (required for ATL headers), ensure to install C++ language support
+* Microsoft Windows Software Development Kit (SDK) from [here](https://go.microsoft.com/fwlink/p/?LinkId=323507) (required for Resource Compiler, rc.exe, use Windows 8.1 SDK) See also: https://stackoverflow.com/questions/14372706/visual-studio-cant-build-due-to-rc-exe
 * Perl for Windows (we use [Strawberry Perl](https://strawberryperl.com/))
 
 ### Build 32bit
@@ -32,7 +34,7 @@ We build patched Windows DLLs on a Windows Server 2016 10.0 node. The following 
 
 ### Build 64bit
 
-* Open "Visual C++ x64 Native Build Tools Command Prompt" (defaults to 64bit compiler & linker settings)
+* Open "VS2015 x64 Native Tools Command Prompt" (defaults to 64bit compiler & linker settings)
 * export JAVA_HOME: `set JAVA_HOME=<your-java-install>`
 * change to `bindings\java`
 * run ant (no target required)


### PR DESCRIPTION
In case the Windows dwMajorVersion was not matching expectations, vendor_name and vendor_version could be uninitialized which causes leaking memory inside the sigar_os_sys_info_get function. It also did not support Windows 10 and Windows Server 2016 according to the Microsoft API docs: https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa#remarks

I compiled the binaries manually on a Windows 2016 Server, as this requires quite a bit of setup effort, I am attaching the output of `sigar\bindings\java\sigar-bin` as zip file: [sigar-bin.zip](https://github.com/instana/sigar/files/12881729/sigar-bin.zip)
