### PR TITLE
INSTA-35086: never let lcpu become 0 to mitigate divide by zero

### DIFF
--- a/include/sigar_util.h
+++ b/include/sigar_util.h
@@ -143,25 +143,12 @@ sigar_iodev_t *sigar_iodev_get(sigar_t *sigar,
 int sigar_cpu_core_count(sigar_t *sigar);
 
 /* e.g. VM guest may have 1 virtual ncpu on multicore hosts */
-static inline int sigar_cpu_socket_count(const sigar_t *sigar) {
-    int ncpu = sigar->ncpu;
-    int lcpu = sigar->lcpu;
-
-    // If we couldn’t detect logical‐per‐socket, just assume
-    // one socket per logical CPU:
-    if (lcpu <= 0) {
-        return ncpu;
-    }
-
-    // If total CPUs is less than “cores per socket”,
-    // fall back to reporting one socket per CPU:
-    if (ncpu < lcpu) {
-        return ncpu;
-    }
-
-    // Otherwise, divide logically to get the number of sockets:
-    return ncpu / lcpu;
-}
+#define sigar_cpu_socket_count(sigar)   \
+    (sigar->lcpu > 0                    \
+       ? (sigar->ncpu < sigar->lcpu     \
+           ? sigar->ncpu                \
+           : (sigar->ncpu/sigar->lcpu)) \
+       : sigar->ncpu)
 
 int sigar_cpu_core_rollup(sigar_t *sigar);
 

--- a/include/sigar_util.h
+++ b/include/sigar_util.h
@@ -143,9 +143,25 @@ sigar_iodev_t *sigar_iodev_get(sigar_t *sigar,
 int sigar_cpu_core_count(sigar_t *sigar);
 
 /* e.g. VM guest may have 1 virtual ncpu on multicore hosts */
-#define sigar_cpu_socket_count(sigar) \
-    (sigar->ncpu < sigar->lcpu) ? sigar->ncpu : \
-    (sigar->ncpu / sigar->lcpu)
+static inline int sigar_cpu_socket_count(const sigar_t *sigar) {
+    int ncpu = sigar->ncpu;
+    int lcpu = sigar->lcpu;
+
+    // If we couldn’t detect logical‐per‐socket, just assume
+    // one socket per logical CPU:
+    if (lcpu <= 0) {
+        return ncpu;
+    }
+
+    // If total CPUs is less than “cores per socket”,
+    // fall back to reporting one socket per CPU:
+    if (ncpu < lcpu) {
+        return ncpu;
+    }
+
+    // Otherwise, divide logically to get the number of sockets:
+    return ncpu / lcpu;
+}
 
 int sigar_cpu_core_rollup(sigar_t *sigar);
 

--- a/src/sigar_util.c
+++ b/src/sigar_util.c
@@ -569,7 +569,8 @@ int sigar_cpu_core_count(sigar_t *sigar)
             sigar_cpuid(1, &id);
 
             if (id.edx & (1<<28)) {
-                sigar->lcpu = (id.ebx & 0x00FF0000) >> 16;
+                unsigned int ht = (id.ebx & 0x00FF0000) >> 16;
+                sigar->lcpu = ht > 1 ? ht : 1;   // never let it drop to 0
             }
         }
 


### PR DESCRIPTION
### Why

There might be a divide by 0 in the `getCpuInfoList()` method.

### How

By checking the code for potential issues, the only divide by zero seems to be the `lcpu` count.