### PR TITLE
INSTA-84262- Fix AIX SIGSEGV crash in filesystem enumeration with zero vmount offsets

### DIFF
--- a/src/os/aix/aix_sigar.c
+++ b/src/os/aix/aix_sigar.c
@@ -1131,6 +1131,21 @@ int sigar_os_fs_type_get(sigar_file_system_t *fsp)
  */
 int mntctl(int command, int size, char *buffer);
 #endif
+/*
+ * Safe wrapper for vmt2dataptr that checks if the field is present.
+ * According to AIX documentation: "If a particular area has no data,
+ * offset and size should be 0."
+ *
+ * This prevents SIGSEGV when vmt_off is 0, which would cause vmt2dataptr
+ * to return a pointer to the vmount structure itself.
+ */
+static inline char* safe_vmt2dataptr(struct vmount *vmt, int idx) {
+    if (vmt->vmt_data[idx].vmt_off == 0 || vmt->vmt_data[idx].vmt_size == 0) {
+        return NULL;
+    }
+    return vmt2dataptr(vmt, idx);
+}
+
 
 int sigar_file_system_list_get(sigar_t *sigar,
                                sigar_file_system_list_t *fslist)
@@ -1193,13 +1208,28 @@ int sigar_file_system_list_get(sigar_t *sigar,
             }
         }
 
-        SIGAR_SSTRCPY(fsp->dir_name, vmt2dataptr(ent, VMT_STUB));
-        SIGAR_SSTRCPY(fsp->options, vmt2dataptr(ent, VMT_ARGS));
+        char *dir_name = safe_vmt2dataptr(ent, VMT_STUB);
+        char *options = safe_vmt2dataptr(ent, VMT_ARGS);
+
+        if (dir_name != NULL) {
+            SIGAR_SSTRCPY(fsp->dir_name, dir_name);
+        } else {
+            fsp->dir_name[0] = '\0';
+        }
         
-        devname = vmt2dataptr(ent, VMT_OBJECT);
+        if (options != NULL) {
+            SIGAR_SSTRCPY(fsp->options, options);
+        } else {
+            fsp->options[0] = '\0';
+        }
+
+        devname = safe_vmt2dataptr(ent, VMT_OBJECT);
+        if (devname == NULL) {
+            devname = "";
+        }
 
         if (fsp->type == SIGAR_FSTYPE_NETWORK) {
-            char *hostname   = vmt2dataptr(ent, VMT_HOSTNAME);
+            char *hostname   = safe_vmt2dataptr(ent, VMT_HOSTNAME);
             
             /* Check if hostname is NULL - some network filesystems (NFS v4, CIFS)
              * may not populate VMT_HOSTNAME field on AIX */


### PR DESCRIPTION
###  🐛  Problem

This PR fixes a critical SIGSEGV crash in the AIX agent during filesystem enumeration. 
```
1XMCURTHDINFO  Current thread
3XMTHREADINFO      "instana-scheduler-thread-3-3" J9VMThread:0x0000000030D25200, omrthread_t:0x000001002BB49570, java/lang/Thread:0x00000000F20CE8E0, state:R, prio=5
3XMJAVALTHREAD            (java/lang/Thread getId:0x50, isDaemon:false)
3XMJAVALTHRCCL            jdk/internal/loader/ClassLoaders$AppClassLoader(0x00000000F0077EC8)
3XMTHREADINFO1            (native thread ID:0x2CB01DB, native priority:0x5, native policy:UNKNOWN, vmstate:R, vm thread flags:0x00000020)
3XMTHREADINFO2            (native stack address range from:0x000001002BED0000, to:0x000001002BF56788, size:0x86788)
3XMCPUTIME               CPU usage total: 117.876476000 secs, user: 36.852702000 secs, system: 81.023774000 secs, current category="Application"
3XMHEAPALLOC             Heap bytes allocated since last GC cycle=65536 (0x10000)
3XMTHREADINFO3           Java callstack:
4XESTACKTRACE                at org/hyperic/sigar/Sigar.getFileSystemListNative(Native Method)
4XESTACKTRACE                at org/hyperic/sigar/Sigar.getFileSystemList(Sigar.java:650(Compiled Code))
4XESTACKTRACE                at com/instana/agent/host/sensor/impl/filesystem/FileSystemHelper.readFileSystems(FileSystemHelper.java:102(Compiled Code))
4XESTACKTRACE                at com/instana/agent/host/sensor/impl/filesystem/FileSystemHelper.collectFileSystemsData(FileSystemHelper.java:188(Compiled Code))
4XESTACKTRACE                at com/instana/agent/host/sensor/Host.lambda$activate$4(Host.java:193(Compiled Code))
.....
3XMTHREADINFO3           Native callstack:
4XENATIVESTACK               Java_org_hyperic_sigar_Sigar_getFileSystemListNative+0xa0 (0x0900000009BA2B84 [libsigar-ppc64-aix-5.so+0x1db84])
4XENATIVESTACK               (0x00000100113C5C74)
4XENATIVESTACK               runJavaThread+0x280 (0x09000000042CCDC4 [libj9vm29.so+0x73dc4])
4XENATIVESTACK               _ZL23javaProtectedThreadProcP13J9PortLibraryPv+0x11c (0x090000000425BFE0 [libj9vm29.so+0x2fe0])
4XENATIVESTACK               omrsig_protect+0x4fc (0x090000000463E1E0 [libj9prt29.so+0x5f1e0])
4XENATIVESTACK               javaThreadProc+0x70 (0x090000000425BE54 [libj9vm29.so+0x2e54])
4XENATIVESTACK               thread_wrapper+0x14c (0x09000000046A8590 [libj9thr29.so+0x5590])
4XENATIVESTACK               (0x090000000008A214 [libpthreads.a+0x214])

```

The agent crashes with SIGSEGV when scanning filesystems that have missing metadata fields (where `vmt_off` is 0). The crash occurs because:

- The AIX vmt2dataptr() macro does not validate if vmt_off is 0 before dereferencing. According to AIX documentation in sys/vmount.h:
`If a particular area has no data, offset and size should be 0.`
- When vmt_off is 0, vmt2dataptr() returns a pointer to the vmount structure itself (not NULL). Dereferencing this as a string causes SIGSEGV.
- The previous fix  commit 06245408 only protected VMT_HOSTNAME field and checked AFTER calling vmt2dataptr(). This approach has two flaws:
              1. The macro never returns NULL - it always returns a pointer
              2. Only 1 of 4 critical fields was protected

### ✅ Solution

Created a comprehensive fix that:

1. **Added `safe_vmt2dataptr()` wrapper function:**
   - Validates `vmt_off` and `vmt_size` **before** calling `vmt2dataptr()`
   - Returns NULL safely when fields are not populated
   - Prevents invalid pointer creation

2. **Updated ALL 4 vmount field accesses:**
   - `VMT_STUB` (line 1211) - **NEW** protection
   - `VMT_ARGS` (line 1212) - **NEW** protection
   - `VMT_OBJECT` (line 1226) - **ENHANCED** protection
   - `VMT_HOSTNAME` (line 1232) - **ENHANCED** protection

### Why This Fix Is Correct

✅ **Follows AIX Documentation:**
```c
/* From /usr/include/sys/vmount.h:
 * The variable length data descriptors are an array of offsets
 * (from beginning of struct vmount) and sizes.
 * NOTES:
 * If a particular area has no data, offset and size should be 0.
 * The size must always be filled in, even if the data is a NULL
 * terminated printable text string.
 */
#define VMT_OBJECT      0       /* I index of object name               */
#define VMT_STUB        1       /* I index of mounted over stub name    */
#define VMT_HOST        2       /* I index of (short) hostname          */
#define VMT_HOSTNAME    3       /* I index of (long) hostname           */
#define VMT_INFO        4       /* I index of binary vfs specific info  */
                                /*   includes network address, opts, etc*/
#define VMT_ARGS        5       /* I index of text of vfs specific args */
 */
```

✅ **Prevents Invalid Pointer Creation:**
- Checks **before** calling macro, not after
- Returns NULL when data is missing
- Allows existing NULL checks to work correctly


### 📂 Files Changed

```
src/os/aix/aix_sigar.c
```

**Changes:**
- Added `safe_vmt2dataptr()` wrapper function 
- Updated 4 `vmt2dataptr()` calls to use safe wrapper


### Ref:
[INSTA-84262](https://jsw.ibm.com/browse/INSTA-84262)