### PR TITLE
INSTA-89756 - fix(aix): Prevent SIGSEGV in filesystem list with comprehensive vmount validation

### DIFF
--- a/bindings/java/src/jni/javasigar.c
+++ b/bindings/java/src/jni/javasigar.c
@@ -498,7 +498,8 @@ JNIEXPORT jobjectArray SIGAR_JNIx(getFileSystemListNative)
                           fs->type);
 
         JENV->SetObjectArrayElement(env, fsarray, i, fsobj);
-        JENV->PopLocalFrame(env, NULL);
+        /* PopLocalFrame with fsobj as second parameter to preserve it in the array */
+        fsobj = JENV->PopLocalFrame(env, fsobj);
         if (JENV->ExceptionCheck(env)) {
             sigar_file_system_list_destroy(sigar, &fslist);
             return NULL;

--- a/src/os/aix/aix_sigar.c
+++ b/src/os/aix/aix_sigar.c
@@ -18,7 +18,7 @@
 
 /* pull in time.h before resource.h does w/ _KERNEL */
 #include <sys/time.h>
-#define _KERNEL 1 
+#define _KERNEL 1
 #include <sys/file.h>     /* for struct file */
 #include <sys/resource.h> /* for rlimit32 in 64-bit mode */
 #undef  _KERNEL
@@ -32,6 +32,8 @@
 #include <nlist.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <utmp.h>
 #include <libperfstat.h>
 #include <pthread.h>
@@ -1138,11 +1140,48 @@ int mntctl(int command, int size, char *buffer);
  *
  * This prevents SIGSEGV when vmt_off is 0, which would cause vmt2dataptr
  * to return a pointer to the vmount structure itself.
+ *
+ * Also validates that idx is within valid range and that the data pointer
+ * would not exceed the vmount structure boundaries.
  */
-static inline char* safe_vmt2dataptr(struct vmount *vmt, int idx) {
-    if (vmt->vmt_data[idx].vmt_off == 0 || vmt->vmt_data[idx].vmt_size == 0) {
+static inline char* safe_vmt2dataptr(struct vmount *vmt, int idx, sigar_t *sigar) {
+    /* Validate index is within bounds - vmt_data array size is limited */
+    if (idx < 0 || idx >= sizeof(vmt->vmt_data) / sizeof(vmt->vmt_data[0])) {
+        if (SIGAR_LOG_IS_DEBUG(sigar)) {
+            sigar_log_printf(sigar, SIGAR_LOG_DEBUG,
+                           "[fs_list] safe_vmt2dataptr: idx=%d out of bounds (max=%lu)",
+                           idx, sizeof(vmt->vmt_data) / sizeof(vmt->vmt_data[0]));
+        }
         return NULL;
     }
+    
+    /* Check if field has data */
+    if (vmt->vmt_data[idx].vmt_off == 0 || vmt->vmt_data[idx].vmt_size == 0) {
+        if (SIGAR_LOG_IS_DEBUG(sigar)) {
+            sigar_log_printf(sigar, SIGAR_LOG_DEBUG,
+                           "[fs_list] safe_vmt2dataptr: idx=%d empty (off=%d, size=%d)",
+                           idx, vmt->vmt_data[idx].vmt_off, vmt->vmt_data[idx].vmt_size);
+        }
+        return NULL;
+    }
+    
+    /* Validate offset is within the vmount structure length */
+    if (vmt->vmt_data[idx].vmt_off >= vmt->vmt_length) {
+        sigar_log_printf(sigar, SIGAR_LOG_WARN,
+                       "[fs_list] safe_vmt2dataptr: idx=%d invalid offset (off=%d >= vmt_length=%d)",
+                       idx, vmt->vmt_data[idx].vmt_off, vmt->vmt_length);
+        return NULL;
+    }
+    
+    /* Validate that size doesn't exceed remaining space (prevents integer overflow) */
+    if (vmt->vmt_data[idx].vmt_size > vmt->vmt_length - vmt->vmt_data[idx].vmt_off) {
+        sigar_log_printf(sigar, SIGAR_LOG_WARN,
+                       "[fs_list] safe_vmt2dataptr: idx=%d size overflow (size=%d > remaining=%d)",
+                       idx, vmt->vmt_data[idx].vmt_size,
+                       vmt->vmt_length - vmt->vmt_data[idx].vmt_off);
+        return NULL;
+    }
+    
     return vmt2dataptr(vmt, idx);
 }
 
@@ -1151,7 +1190,7 @@ int sigar_file_system_list_get(sigar_t *sigar,
                                sigar_file_system_list_t *fslist)
 {
     int i, size, num;
-    char *buf, *mntlist;
+    char *buf, *mntlist, *buf_end;
 
     /* get required size */
     if (mntctl(MCTL_QUERY, sizeof(size), (char *)&size) < 0) {
@@ -1159,6 +1198,11 @@ int sigar_file_system_list_get(sigar_t *sigar,
     }
 
     mntlist = buf = malloc(size);
+    if (buf == NULL) {
+        return errno;
+    }
+    
+    buf_end = buf + size;
 
     if ((num = mntctl(MCTL_QUERY, size, buf)) < 0) {
         free(buf);
@@ -1167,13 +1211,67 @@ int sigar_file_system_list_get(sigar_t *sigar,
 
     sigar_file_system_list_create(fslist);
 
+    {
+        FILE *debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] Starting filesystem list: num=%d, buf=%p, buf_end=%p, size=%d\n",
+                    time(NULL), num, (void*)buf, (void*)buf_end, size);
+            fclose(debug_log);
+        }
+    }
+
     for (i=0; i<num; i++) {
         char *devname;
         const char *typename = NULL;
         sigar_file_system_t *fsp;
         struct vmount *ent = (struct vmount *)mntlist;
+        FILE *debug_log = NULL;
+        
+        debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] Entry %d: mntlist=%p, ent=%p\n",
+                    time(NULL), i, (void*)mntlist, (void*)ent);
+            fclose(debug_log);
+        }
+        
+        /* Safety check: ensure we can read the vmount header */
+        if (mntlist + sizeof(struct vmount) > buf_end) {
+            debug_log = fopen("/tmp/sigar_debug.log", "a");
+            if (debug_log) {
+                fprintf(debug_log, "[%ld] Entry %d: BREAK - header beyond buffer\n",
+                        time(NULL), i);
+                fclose(debug_log);
+            }
+            break;
+        }
+        
+        debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] Entry %d: vmt_length=%d, vmt_gfstype=%d, vmt_flags=0x%x\n",
+                    time(NULL), i, ent->vmt_length, ent->vmt_gfstype, ent->vmt_flags);
+            fclose(debug_log);
+        }
+        
+        /* Safety check: validate vmt_length before using it */
+        if (ent->vmt_length < sizeof(struct vmount) ||
+            mntlist + ent->vmt_length > buf_end) {
+            debug_log = fopen("/tmp/sigar_debug.log", "a");
+            if (debug_log) {
+                fprintf(debug_log, "[%ld] Entry %d: BREAK - invalid vmt_length=%d (min=%lu)\n",
+                        time(NULL), i, ent->vmt_length, sizeof(struct vmount));
+                fclose(debug_log);
+            }
+            break;
+        }
 
         mntlist += ent->vmt_length;
+        
+        debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] Entry %d: Advanced mntlist to %p\n",
+                    time(NULL), i, (void*)mntlist);
+            fclose(debug_log);
+        }
 
         SIGAR_FILE_SYSTEM_LIST_GROW(fslist);
 
@@ -1208,8 +1306,31 @@ int sigar_file_system_list_get(sigar_t *sigar,
             }
         }
 
+        debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] Entry %d: Accessing VMT_STUB\n", time(NULL), i);
+            fclose(debug_log);
+        }
         char *dir_name = safe_vmt2dataptr(ent, VMT_STUB);
+        debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] Entry %d: VMT_STUB=%s\n",
+                    time(NULL), i, dir_name ? dir_name : "NULL");
+            fclose(debug_log);
+        }
+
+        debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] Entry %d: Accessing VMT_ARGS\n", time(NULL), i);
+            fclose(debug_log);
+        }
         char *options = safe_vmt2dataptr(ent, VMT_ARGS);
+        debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] Entry %d: VMT_ARGS=%s\n",
+                    time(NULL), i, options ? options : "NULL");
+            fclose(debug_log);
+        }
 
         if (dir_name != NULL) {
             SIGAR_SSTRCPY(fsp->dir_name, dir_name);
@@ -1223,13 +1344,36 @@ int sigar_file_system_list_get(sigar_t *sigar,
             fsp->options[0] = '\0';
         }
 
+        debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] Entry %d: Accessing VMT_OBJECT\n", time(NULL), i);
+            fclose(debug_log);
+        }
         devname = safe_vmt2dataptr(ent, VMT_OBJECT);
+        debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] Entry %d: VMT_OBJECT=%s\n",
+                    time(NULL), i, devname ? devname : "NULL");
+            fclose(debug_log);
+        }
         if (devname == NULL) {
             devname = "";
         }
 
         if (fsp->type == SIGAR_FSTYPE_NETWORK) {
+            debug_log = fopen("/tmp/sigar_debug.log", "a");
+            if (debug_log) {
+                fprintf(debug_log, "[%ld] Entry %d: Network FS - Accessing VMT_HOSTNAME\n",
+                        time(NULL), i);
+                fclose(debug_log);
+            }
             char *hostname   = safe_vmt2dataptr(ent, VMT_HOSTNAME);
+            debug_log = fopen("/tmp/sigar_debug.log", "a");
+            if (debug_log) {
+                fprintf(debug_log, "[%ld] Entry %d: VMT_HOSTNAME=%s\n",
+                        time(NULL), i, hostname ? hostname : "NULL");
+                fclose(debug_log);
+            }
             
             /* Check if hostname is NULL - some network filesystems (NFS v4, CIFS)
              * may not populate VMT_HOSTNAME field on AIX */
@@ -1277,6 +1421,15 @@ int sigar_file_system_list_get(sigar_t *sigar,
         }
 
         SIGAR_SSTRCPY(fsp->sys_type_name, typename);
+    }
+
+    {
+        FILE *debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] Completed filesystem list successfully: processed %d entries\n",
+                    time(NULL), i);
+            fclose(debug_log);
+        }
     }
 
     free(buf);

--- a/src/os/aix/aix_sigar.c
+++ b/src/os/aix/aix_sigar.c
@@ -1221,13 +1221,12 @@ int sigar_file_system_list_get(sigar_t *sigar,
 
     sigar_file_system_list_create(fslist);
 
-    {
-        FILE *debug_log = fopen("/tmp/sigar_debug.log", "a");
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] Starting filesystem list: num=%d, buf=%p, buf_end=%p, size=%d\n",
-                    time(NULL), num, (void*)buf, (void*)buf_end, size);
-            fclose(debug_log);
-        }
+    /* Open debug log once for entire function - better performance */
+    FILE *debug_log = fopen("/tmp/sigar_debug.log", "a");
+    if (debug_log) {
+        fprintf(debug_log, "[%ld] Starting filesystem list: num=%d, buf=%p, buf_end=%p, size=%d\n",
+                time(NULL), num, (void*)buf, (void*)buf_end, size);
+        fflush(debug_log);  /* Ensure written immediately */
     }
 
     for (i=0; i<num; i++) {
@@ -1235,52 +1234,46 @@ int sigar_file_system_list_get(sigar_t *sigar,
         const char *typename = NULL;
         sigar_file_system_t *fsp;
         struct vmount *ent = (struct vmount *)mntlist;
-        FILE *debug_log = NULL;
         
-        debug_log = fopen("/tmp/sigar_debug.log", "a");
         if (debug_log) {
             fprintf(debug_log, "[%ld] Entry %d: mntlist=%p, ent=%p\n",
                     time(NULL), i, (void*)mntlist, (void*)ent);
-            fclose(debug_log);
+            fflush(debug_log);
         }
         
         /* Safety check: ensure we can read the vmount header */
         if (mntlist + sizeof(struct vmount) > buf_end) {
-            debug_log = fopen("/tmp/sigar_debug.log", "a");
             if (debug_log) {
                 fprintf(debug_log, "[%ld] Entry %d: BREAK - header beyond buffer\n",
                         time(NULL), i);
-                fclose(debug_log);
+                fflush(debug_log);
             }
             break;
         }
         
-        debug_log = fopen("/tmp/sigar_debug.log", "a");
         if (debug_log) {
             fprintf(debug_log, "[%ld] Entry %d: vmt_length=%d, vmt_gfstype=%d, vmt_flags=0x%x\n",
                     time(NULL), i, ent->vmt_length, ent->vmt_gfstype, ent->vmt_flags);
-            fclose(debug_log);
+            fflush(debug_log);
         }
         
         /* Safety check: validate vmt_length before using it */
         if (ent->vmt_length < sizeof(struct vmount) ||
             mntlist + ent->vmt_length > buf_end) {
-            debug_log = fopen("/tmp/sigar_debug.log", "a");
             if (debug_log) {
                 fprintf(debug_log, "[%ld] Entry %d: BREAK - invalid vmt_length=%d (min=%lu)\n",
                         time(NULL), i, ent->vmt_length, sizeof(struct vmount));
-                fclose(debug_log);
+                fflush(debug_log);
             }
             break;
         }
 
         mntlist += ent->vmt_length;
         
-        debug_log = fopen("/tmp/sigar_debug.log", "a");
         if (debug_log) {
             fprintf(debug_log, "[%ld] Entry %d: Advanced mntlist to %p\n",
                     time(NULL), i, (void*)mntlist);
-            fclose(debug_log);
+            fflush(debug_log);
         }
 
         SIGAR_FILE_SYSTEM_LIST_GROW(fslist);
@@ -1316,30 +1309,26 @@ int sigar_file_system_list_get(sigar_t *sigar,
             }
         }
 
-        debug_log = fopen("/tmp/sigar_debug.log", "a");
         if (debug_log) {
             fprintf(debug_log, "[%ld] Entry %d: Accessing VMT_STUB\n", time(NULL), i);
-            fclose(debug_log);
+            fflush(debug_log);
         }
         char *dir_name = safe_vmt2dataptr(ent, VMT_STUB);
-        debug_log = fopen("/tmp/sigar_debug.log", "a");
         if (debug_log) {
             fprintf(debug_log, "[%ld] Entry %d: VMT_STUB=%s\n",
                     time(NULL), i, dir_name ? dir_name : "NULL");
-            fclose(debug_log);
+            fflush(debug_log);
         }
 
-        debug_log = fopen("/tmp/sigar_debug.log", "a");
         if (debug_log) {
             fprintf(debug_log, "[%ld] Entry %d: Accessing VMT_ARGS\n", time(NULL), i);
-            fclose(debug_log);
+            fflush(debug_log);
         }
         char *options = safe_vmt2dataptr(ent, VMT_ARGS);
-        debug_log = fopen("/tmp/sigar_debug.log", "a");
         if (debug_log) {
             fprintf(debug_log, "[%ld] Entry %d: VMT_ARGS=%s\n",
                     time(NULL), i, options ? options : "NULL");
-            fclose(debug_log);
+            fflush(debug_log);
         }
 
         if (dir_name != NULL) {
@@ -1354,35 +1343,31 @@ int sigar_file_system_list_get(sigar_t *sigar,
             fsp->options[0] = '\0';
         }
 
-        debug_log = fopen("/tmp/sigar_debug.log", "a");
         if (debug_log) {
             fprintf(debug_log, "[%ld] Entry %d: Accessing VMT_OBJECT\n", time(NULL), i);
-            fclose(debug_log);
+            fflush(debug_log);
         }
         devname = safe_vmt2dataptr(ent, VMT_OBJECT);
-        debug_log = fopen("/tmp/sigar_debug.log", "a");
         if (debug_log) {
             fprintf(debug_log, "[%ld] Entry %d: VMT_OBJECT=%s\n",
                     time(NULL), i, devname ? devname : "NULL");
-            fclose(debug_log);
+            fflush(debug_log);
         }
         if (devname == NULL) {
             devname = "";
         }
 
         if (fsp->type == SIGAR_FSTYPE_NETWORK) {
-            debug_log = fopen("/tmp/sigar_debug.log", "a");
             if (debug_log) {
                 fprintf(debug_log, "[%ld] Entry %d: Network FS - Accessing VMT_HOSTNAME\n",
                         time(NULL), i);
-                fclose(debug_log);
+                fflush(debug_log);
             }
             char *hostname   = safe_vmt2dataptr(ent, VMT_HOSTNAME);
-            debug_log = fopen("/tmp/sigar_debug.log", "a");
             if (debug_log) {
                 fprintf(debug_log, "[%ld] Entry %d: VMT_HOSTNAME=%s\n",
                         time(NULL), i, hostname ? hostname : "NULL");
-                fclose(debug_log);
+                fflush(debug_log);
             }
             
             /* Check if hostname is NULL - some network filesystems (NFS v4, CIFS)
@@ -1433,13 +1418,10 @@ int sigar_file_system_list_get(sigar_t *sigar,
         SIGAR_SSTRCPY(fsp->sys_type_name, typename);
     }
 
-    {
-        FILE *debug_log = fopen("/tmp/sigar_debug.log", "a");
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] Completed filesystem list successfully: processed %d entries\n",
-                    time(NULL), i);
-            fclose(debug_log);
-        }
+    if (debug_log) {
+        fprintf(debug_log, "[%ld] Completed filesystem list successfully: processed %d entries\n",
+                time(NULL), i);
+        fclose(debug_log);  /* Close the debug log file */
     }
 
     free(buf);

--- a/src/os/aix/aix_sigar.c
+++ b/src/os/aix/aix_sigar.c
@@ -1207,33 +1207,13 @@ static inline char *safe_vmt2dataptr(struct vmount *vmt, int idx)
         return NULL;
     }
 
-    /*
-     * Ensure the string is NUL-terminated within the declared size.
+   /*
+     * Safe to compute the final pointer.
      *
-     * AIX vmount API specifies that string fields are NUL-terminated
-     * and vmt_size includes the NUL byte. However, we validate this
-     * explicitly to protect against:
-     *   - Kernel bugs that violate the API contract
-     *   - Memory corruption in kernel space
-     *   - Malformed vmount structures
-     *
-     * Without this check, strlen() or strncpy() could read past the
-     * validated bounds and potentially SIGSEGV on unmapped memory.
-     *
-     * This is the final defense layer ensuring complete memory safety.
+     * The returned pointer references data fully contained within
+     * the vmount structure according to vmt_length.
      */
-    char *ptr = (char *)vmt + off;
-    if (memchr(ptr, '\0', size) == NULL) {
-        return NULL;
-    }
-
-    /*
-     * Safe to return the pointer.
-     *
-     * The returned pointer references a NUL-terminated string fully
-     * contained within the vmount structure according to vmt_length.
-     */
-    return ptr;
+    return (char *)vmt + off;
 }
 
 

--- a/src/os/aix/aix_sigar.c
+++ b/src/os/aix/aix_sigar.c
@@ -1216,11 +1216,32 @@ static inline char *safe_vmt2dataptr(struct vmount *vmt, int idx)
     return (char *)vmt + off;
 }
 
+/*
+ * Check if a mount point already exists in the filesystem list.
+ * Returns 1 if found, 0 otherwise.
+ */
+static int contains_mount_point(sigar_file_system_list_t *fslist,
+                                const char *dir_name)
+{
+    int j;
+
+    if (dir_name == NULL || *dir_name == '\0') {
+        return 0;
+    }
+
+    for (j = 0; j < (int)fslist->number; j++) {
+        if (strcmp(fslist->data[j].dir_name, dir_name) == 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
 
 int sigar_file_system_list_get(sigar_t *sigar,
                                sigar_file_system_list_t *fslist)
 {
-    int i, j, size, num;
+    int i, size, num;
     char *buf, *mntlist, *buf_end;
 
     /* get required size */
@@ -1265,6 +1286,31 @@ int sigar_file_system_list_get(sigar_t *sigar,
 
         mntlist += ent->vmt_length;
 
+        char *dir_name = safe_vmt2dataptr(ent, VMT_STUB);
+        char *options = safe_vmt2dataptr(ent, VMT_ARGS);
+
+        devname = safe_vmt2dataptr(ent, VMT_OBJECT);
+        if (devname == NULL) {
+            devname = "";
+        }
+
+        /* Skip filesystems with NULL or empty dir_name or devname
+         * to prevent JNI crashes.
+         */
+        if (dir_name == NULL || *dir_name == '\0' ||
+            devname == NULL || *devname == '\0') {
+            continue;
+        }
+
+        /* Check for duplicate mount points.
+         * AIX can report the same mount point multiple times
+         * (for example stale NFS entries).
+         */
+        if (contains_mount_point(fslist, dir_name)) {
+            continue;
+        }
+
+        /* Only allocate a new entry once we know we keep it. */
         SIGAR_FILE_SYSTEM_LIST_GROW(fslist);
 
         fsp = &fslist->data[fslist->number++];
@@ -1274,18 +1320,22 @@ int sigar_file_system_list_get(sigar_t *sigar,
             typename = "aix";
             fsp->type = SIGAR_FSTYPE_LOCAL_DISK;
             break;
+
           case MNT_JFS:
             typename = "jfs";
             fsp->type = SIGAR_FSTYPE_LOCAL_DISK;
             break;
+
           case MNT_NFS:
           case MNT_NFS3:
             typename = "nfs";
             fsp->type = SIGAR_FSTYPE_NETWORK;
             break;
+
           case MNT_CDROM:
             fsp->type = SIGAR_FSTYPE_CDROM;
             break;
+
           case MNT_SFS:
           case MNT_CACHEFS:
           case MNT_AUTOFS:
@@ -1298,73 +1348,40 @@ int sigar_file_system_list_get(sigar_t *sigar,
             }
         }
 
-        char *dir_name = safe_vmt2dataptr(ent, VMT_STUB);
-        char *options = safe_vmt2dataptr(ent, VMT_ARGS);
+        SIGAR_SSTRCPY(fsp->dir_name, dir_name);
 
-        if (dir_name != NULL) {
-            SIGAR_SSTRCPY(fsp->dir_name, dir_name);
-        } else {
-            fsp->dir_name[0] = '\0';
-        }
-        
         if (options != NULL) {
             SIGAR_SSTRCPY(fsp->options, options);
-        } else {
+        }
+        else {
             fsp->options[0] = '\0';
         }
 
-        devname = safe_vmt2dataptr(ent, VMT_OBJECT);
-        if (devname == NULL) {
-            devname = "";
-        }
-
-        /* Skip filesystems with NULL or empty dir_name or devname to prevent JNI crashes */
-        if (dir_name == NULL || *dir_name == '\0' || devname == NULL || *devname == '\0') {
-            fslist->number--;
-            continue;
-        }
-
-        /* Check for duplicate mount points - AIX can report the same mount point multiple times
-         * (e.g., stale NFS mounts). The JNI layer cannot handle duplicates and will crash.
-         * Skip subsequent occurrences of the same mount point. */
-        int is_duplicate = 0;
-        for (j = 0; j < (int)(fslist->number - 1); j++) {
-            if (strcmp(fslist->data[j].dir_name, dir_name) == 0) {
-                is_duplicate = 1;
-                break;
-            }
-        }
-        if (is_duplicate) {
-            fslist->number--;
-            continue;
-        }
-
         if (fsp->type == SIGAR_FSTYPE_NETWORK) {
-            char *hostname   = safe_vmt2dataptr(ent, VMT_HOSTNAME);
-            
-            /* Check if hostname is NULL - some network filesystems (NFS v4, CIFS)
-             * may not populate VMT_HOSTNAME field on AIX */
+            char *hostname = safe_vmt2dataptr(ent, VMT_HOSTNAME);
+
+            /* Some network filesystems (NFSv4, CIFS, stale mounts)
+             * may not populate VMT_HOSTNAME on AIX.
+             */
             if (hostname == NULL || *hostname == '\0') {
-                /* No hostname available, just use device name */
                 SIGAR_SSTRCPY(fsp->dev_name, devname);
             }
             else {
 #if 0
                 /* XXX: these do not seem reliable */
-                int hostname_len = vmt2datasize(ent, VMT_HOSTNAME)-1; /* -1 == skip '\0' */
-                int devname_len  = vmt2datasize(ent, VMT_OBJECT);     /* includes '\0' */
+                int hostname_len = vmt2datasize(ent, VMT_HOSTNAME) - 1;
+                int devname_len  = vmt2datasize(ent, VMT_OBJECT);
 #else
                 int hostname_len = strlen(hostname);
-                int devname_len = strlen(devname) + 1;
+                int devname_len  = strlen(devname) + 1;
 #endif
-                int total_len    = hostname_len + devname_len + 1;    /* 1 == strlen(":") */
+                int total_len = hostname_len + devname_len + 1;
 
                 if (total_len > sizeof(fsp->dev_name)) {
-                    /* justincase - prevent overflow.  chances: slim..none */
+                    /* Prevent overflow */
                     SIGAR_SSTRCPY(fsp->dev_name, devname);
                 }
                 else {
-                    /* sprintf(fsp->devname, "%s:%s", hostname, devname) */
                     char *ptr = fsp->dev_name;
 
                     memcpy(ptr, hostname, hostname_len);
@@ -1380,7 +1397,7 @@ int sigar_file_system_list_get(sigar_t *sigar,
             SIGAR_SSTRCPY(fsp->dev_name, devname);
         }
 
-        /* we set fsp->type, just looking up sigar.c:fstype_names[type] */
+        /* Populate additional filesystem type information */
         sigar_fs_type_get(fsp);
 
         if (typename == NULL) {

--- a/src/os/aix/aix_sigar.c
+++ b/src/os/aix/aix_sigar.c
@@ -1145,50 +1145,33 @@ int mntctl(int command, int size, char *buffer);
  * would not exceed the vmount structure boundaries.
  */
 static inline char* safe_vmt2dataptr(struct vmount *vmt, int idx) {
-    FILE *debug_log = NULL;
+    /* Validate vmount pointer */
+    if (vmt == NULL) {
+        return NULL;
+    }
+
+    /* Validate vmt_length is reasonable (minimum size check) */
+    if (vmt->vmt_length < sizeof(struct vmount)) {
+        return NULL;
+    }
     
     /* Array bounds check: VMT_LASTINDEX is 5, so valid indices are 0-5 */
     if (idx < 0 || idx >= sizeof(vmt->vmt_data) / sizeof(vmt->vmt_data[0])) {
-        debug_log = fopen("/tmp/sigar_debug.log", "a");
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] safe_vmt2dataptr: idx=%d out of bounds (max=%lu)\n",
-                   time(NULL), idx, sizeof(vmt->vmt_data) / sizeof(vmt->vmt_data[0]) - 1);
-            fclose(debug_log);
-        }
         return NULL;
     }
     
     /* Check if field is empty (offset or size is 0) */
     if (vmt->vmt_data[idx].vmt_off == 0 || vmt->vmt_data[idx].vmt_size == 0) {
-        debug_log = fopen("/tmp/sigar_debug.log", "a");
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] safe_vmt2dataptr: idx=%d empty (off=%d, size=%d)\n",
-                   time(NULL), idx, vmt->vmt_data[idx].vmt_off, vmt->vmt_data[idx].vmt_size);
-            fclose(debug_log);
-        }
         return NULL;
     }
     
     /* Validate offset is within vmt_length */
     if (vmt->vmt_data[idx].vmt_off >= vmt->vmt_length) {
-        debug_log = fopen("/tmp/sigar_debug.log", "a");
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] safe_vmt2dataptr: idx=%d invalid offset (off=%d >= vmt_length=%d)\n",
-                   time(NULL), idx, vmt->vmt_data[idx].vmt_off, vmt->vmt_length);
-            fclose(debug_log);
-        }
         return NULL;
     }
     
     /* Overflow-safe size check: ensure size doesn't exceed remaining buffer */
     if (vmt->vmt_data[idx].vmt_size > vmt->vmt_length - vmt->vmt_data[idx].vmt_off) {
-        debug_log = fopen("/tmp/sigar_debug.log", "a");
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] safe_vmt2dataptr: idx=%d size overflow (size=%d > remaining=%d)\n",
-                   time(NULL), idx, vmt->vmt_data[idx].vmt_size,
-                   vmt->vmt_length - vmt->vmt_data[idx].vmt_off);
-            fclose(debug_log);
-        }
         return NULL;
     }
     
@@ -1221,60 +1204,24 @@ int sigar_file_system_list_get(sigar_t *sigar,
 
     sigar_file_system_list_create(fslist);
 
-    /* Open debug log once for entire function - better performance */
-    FILE *debug_log = fopen("/tmp/sigar_debug.log", "a");
-    if (debug_log) {
-        fprintf(debug_log, "[%ld] Starting filesystem list: num=%d, buf=%p, buf_end=%p, size=%d\n",
-                time(NULL), num, (void*)buf, (void*)buf_end, size);
-        fflush(debug_log);  /* Ensure written immediately */
-    }
-
     for (i=0; i<num; i++) {
         char *devname;
         const char *typename = NULL;
         sigar_file_system_t *fsp;
         struct vmount *ent = (struct vmount *)mntlist;
         
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] Entry %d: mntlist=%p, ent=%p\n",
-                    time(NULL), i, (void*)mntlist, (void*)ent);
-            fflush(debug_log);
-        }
-        
         /* Safety check: ensure we can read the vmount header */
         if (mntlist + sizeof(struct vmount) > buf_end) {
-            if (debug_log) {
-                fprintf(debug_log, "[%ld] Entry %d: BREAK - header beyond buffer\n",
-                        time(NULL), i);
-                fflush(debug_log);
-            }
             break;
-        }
-        
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] Entry %d: vmt_length=%d, vmt_gfstype=%d, vmt_flags=0x%x\n",
-                    time(NULL), i, ent->vmt_length, ent->vmt_gfstype, ent->vmt_flags);
-            fflush(debug_log);
         }
         
         /* Safety check: validate vmt_length before using it */
         if (ent->vmt_length < sizeof(struct vmount) ||
             mntlist + ent->vmt_length > buf_end) {
-            if (debug_log) {
-                fprintf(debug_log, "[%ld] Entry %d: BREAK - invalid vmt_length=%d (min=%lu)\n",
-                        time(NULL), i, ent->vmt_length, sizeof(struct vmount));
-                fflush(debug_log);
-            }
             break;
         }
 
         mntlist += ent->vmt_length;
-        
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] Entry %d: Advanced mntlist to %p\n",
-                    time(NULL), i, (void*)mntlist);
-            fflush(debug_log);
-        }
 
         SIGAR_FILE_SYSTEM_LIST_GROW(fslist);
 
@@ -1309,27 +1256,8 @@ int sigar_file_system_list_get(sigar_t *sigar,
             }
         }
 
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] Entry %d: Accessing VMT_STUB\n", time(NULL), i);
-            fflush(debug_log);
-        }
         char *dir_name = safe_vmt2dataptr(ent, VMT_STUB);
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] Entry %d: VMT_STUB=%s\n",
-                    time(NULL), i, dir_name ? dir_name : "NULL");
-            fflush(debug_log);
-        }
-
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] Entry %d: Accessing VMT_ARGS\n", time(NULL), i);
-            fflush(debug_log);
-        }
         char *options = safe_vmt2dataptr(ent, VMT_ARGS);
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] Entry %d: VMT_ARGS=%s\n",
-                    time(NULL), i, options ? options : "NULL");
-            fflush(debug_log);
-        }
 
         if (dir_name != NULL) {
             SIGAR_SSTRCPY(fsp->dir_name, dir_name);
@@ -1343,32 +1271,13 @@ int sigar_file_system_list_get(sigar_t *sigar,
             fsp->options[0] = '\0';
         }
 
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] Entry %d: Accessing VMT_OBJECT\n", time(NULL), i);
-            fflush(debug_log);
-        }
         devname = safe_vmt2dataptr(ent, VMT_OBJECT);
-        if (debug_log) {
-            fprintf(debug_log, "[%ld] Entry %d: VMT_OBJECT=%s\n",
-                    time(NULL), i, devname ? devname : "NULL");
-            fflush(debug_log);
-        }
         if (devname == NULL) {
             devname = "";
         }
 
         if (fsp->type == SIGAR_FSTYPE_NETWORK) {
-            if (debug_log) {
-                fprintf(debug_log, "[%ld] Entry %d: Network FS - Accessing VMT_HOSTNAME\n",
-                        time(NULL), i);
-                fflush(debug_log);
-            }
             char *hostname   = safe_vmt2dataptr(ent, VMT_HOSTNAME);
-            if (debug_log) {
-                fprintf(debug_log, "[%ld] Entry %d: VMT_HOSTNAME=%s\n",
-                        time(NULL), i, hostname ? hostname : "NULL");
-                fflush(debug_log);
-            }
             
             /* Check if hostname is NULL - some network filesystems (NFS v4, CIFS)
              * may not populate VMT_HOSTNAME field on AIX */
@@ -1416,12 +1325,6 @@ int sigar_file_system_list_get(sigar_t *sigar,
         }
 
         SIGAR_SSTRCPY(fsp->sys_type_name, typename);
-    }
-
-    if (debug_log) {
-        fprintf(debug_log, "[%ld] Completed filesystem list successfully: processed %d entries\n",
-                time(NULL), i);
-        fclose(debug_log);  /* Close the debug log file */
     }
 
     free(buf);

--- a/src/os/aix/aix_sigar.c
+++ b/src/os/aix/aix_sigar.c
@@ -1208,12 +1208,32 @@ static inline char *safe_vmt2dataptr(struct vmount *vmt, int idx)
     }
 
     /*
-     * Safe to compute the final pointer.
+     * Ensure the string is NUL-terminated within the declared size.
      *
-     * The returned pointer references data fully contained within
-     * the vmount structure according to vmt_length.
+     * AIX vmount API specifies that string fields are NUL-terminated
+     * and vmt_size includes the NUL byte. However, we validate this
+     * explicitly to protect against:
+     *   - Kernel bugs that violate the API contract
+     *   - Memory corruption in kernel space
+     *   - Malformed vmount structures
+     *
+     * Without this check, strlen() or strncpy() could read past the
+     * validated bounds and potentially SIGSEGV on unmapped memory.
+     *
+     * This is the final defense layer ensuring complete memory safety.
      */
-    return (char *)vmt + off;
+    char *ptr = (char *)vmt + off;
+    if (memchr(ptr, '\0', size) == NULL) {
+        return NULL;
+    }
+
+    /*
+     * Safe to return the pointer.
+     *
+     * The returned pointer references a NUL-terminated string fully
+     * contained within the vmount structure according to vmt_length.
+     */
+    return ptr;
 }
 
 
@@ -1230,7 +1250,7 @@ int sigar_file_system_list_get(sigar_t *sigar,
 
     mntlist = buf = malloc(size);
     if (buf == NULL) {
-        return errno;
+        return ENOMEM;
     }
     
     buf_end = buf + size;
@@ -1248,14 +1268,18 @@ int sigar_file_system_list_get(sigar_t *sigar,
         sigar_file_system_t *fsp;
         struct vmount *ent = (struct vmount *)mntlist;
         
-        /* Safety check: ensure we can read the vmount header */
-        if (mntlist + sizeof(struct vmount) > buf_end) {
+        /*
+         * Safety check: ensure we can read the vmount header.
+         */
+        if ((size_t)(buf_end - mntlist) < sizeof(struct vmount)) {
             break;
         }
         
-        /* Safety check: validate vmt_length before using it */
+        /*
+         * Safety check: validate vmt_length before using it.
+         */
         if (ent->vmt_length < sizeof(struct vmount) ||
-            mntlist + ent->vmt_length > buf_end) {
+            ent->vmt_length > (size_t)(buf_end - mntlist)) {
             break;
         }
 

--- a/src/os/aix/aix_sigar.c
+++ b/src/os/aix/aix_sigar.c
@@ -1144,41 +1144,51 @@ int mntctl(int command, int size, char *buffer);
  * Also validates that idx is within valid range and that the data pointer
  * would not exceed the vmount structure boundaries.
  */
-static inline char* safe_vmt2dataptr(struct vmount *vmt, int idx, sigar_t *sigar) {
-    /* Validate index is within bounds - vmt_data array size is limited */
+static inline char* safe_vmt2dataptr(struct vmount *vmt, int idx) {
+    FILE *debug_log = NULL;
+    
+    /* Array bounds check: VMT_LASTINDEX is 5, so valid indices are 0-5 */
     if (idx < 0 || idx >= sizeof(vmt->vmt_data) / sizeof(vmt->vmt_data[0])) {
-        if (SIGAR_LOG_IS_DEBUG(sigar)) {
-            sigar_log_printf(sigar, SIGAR_LOG_DEBUG,
-                           "[fs_list] safe_vmt2dataptr: idx=%d out of bounds (max=%lu)",
-                           idx, sizeof(vmt->vmt_data) / sizeof(vmt->vmt_data[0]));
+        debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] safe_vmt2dataptr: idx=%d out of bounds (max=%lu)\n",
+                   time(NULL), idx, sizeof(vmt->vmt_data) / sizeof(vmt->vmt_data[0]) - 1);
+            fclose(debug_log);
         }
         return NULL;
     }
     
-    /* Check if field has data */
+    /* Check if field is empty (offset or size is 0) */
     if (vmt->vmt_data[idx].vmt_off == 0 || vmt->vmt_data[idx].vmt_size == 0) {
-        if (SIGAR_LOG_IS_DEBUG(sigar)) {
-            sigar_log_printf(sigar, SIGAR_LOG_DEBUG,
-                           "[fs_list] safe_vmt2dataptr: idx=%d empty (off=%d, size=%d)",
-                           idx, vmt->vmt_data[idx].vmt_off, vmt->vmt_data[idx].vmt_size);
+        debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] safe_vmt2dataptr: idx=%d empty (off=%d, size=%d)\n",
+                   time(NULL), idx, vmt->vmt_data[idx].vmt_off, vmt->vmt_data[idx].vmt_size);
+            fclose(debug_log);
         }
         return NULL;
     }
     
-    /* Validate offset is within the vmount structure length */
+    /* Validate offset is within vmt_length */
     if (vmt->vmt_data[idx].vmt_off >= vmt->vmt_length) {
-        sigar_log_printf(sigar, SIGAR_LOG_WARN,
-                       "[fs_list] safe_vmt2dataptr: idx=%d invalid offset (off=%d >= vmt_length=%d)",
-                       idx, vmt->vmt_data[idx].vmt_off, vmt->vmt_length);
+        debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] safe_vmt2dataptr: idx=%d invalid offset (off=%d >= vmt_length=%d)\n",
+                   time(NULL), idx, vmt->vmt_data[idx].vmt_off, vmt->vmt_length);
+            fclose(debug_log);
+        }
         return NULL;
     }
     
-    /* Validate that size doesn't exceed remaining space (prevents integer overflow) */
+    /* Overflow-safe size check: ensure size doesn't exceed remaining buffer */
     if (vmt->vmt_data[idx].vmt_size > vmt->vmt_length - vmt->vmt_data[idx].vmt_off) {
-        sigar_log_printf(sigar, SIGAR_LOG_WARN,
-                       "[fs_list] safe_vmt2dataptr: idx=%d size overflow (size=%d > remaining=%d)",
-                       idx, vmt->vmt_data[idx].vmt_size,
-                       vmt->vmt_length - vmt->vmt_data[idx].vmt_off);
+        debug_log = fopen("/tmp/sigar_debug.log", "a");
+        if (debug_log) {
+            fprintf(debug_log, "[%ld] safe_vmt2dataptr: idx=%d size overflow (size=%d > remaining=%d)\n",
+                   time(NULL), idx, vmt->vmt_data[idx].vmt_size,
+                   vmt->vmt_length - vmt->vmt_data[idx].vmt_off);
+            fclose(debug_log);
+        }
         return NULL;
     }
     

--- a/src/os/aix/aix_sigar.c
+++ b/src/os/aix/aix_sigar.c
@@ -1144,38 +1144,76 @@ int mntctl(int command, int size, char *buffer);
  * Also validates that idx is within valid range and that the data pointer
  * would not exceed the vmount structure boundaries.
  */
-static inline char* safe_vmt2dataptr(struct vmount *vmt, int idx) {
+static inline char *safe_vmt2dataptr(struct vmount *vmt, int idx)
+{
     /* Validate vmount pointer */
     if (vmt == NULL) {
         return NULL;
     }
 
-    /* Validate vmt_length is reasonable (minimum size check) */
+    /*
+     * Validate that the reported vmount length is at least large
+     * enough to contain the fixed vmount structure itself.
+     */
     if (vmt->vmt_length < sizeof(struct vmount)) {
         return NULL;
     }
-    
-    /* Array bounds check: VMT_LASTINDEX is 5, so valid indices are 0-5 */
-    if (idx < 0 || idx >= sizeof(vmt->vmt_data) / sizeof(vmt->vmt_data[0])) {
+
+    /*
+     * Validate array index.
+     *
+     * VMT_LASTINDEX is the last valid entry in vmt_data[].
+     */
+    if (idx < 0 || idx > VMT_LASTINDEX) {
         return NULL;
     }
-    
-    /* Check if field is empty (offset or size is 0) */
-    if (vmt->vmt_data[idx].vmt_off == 0 || vmt->vmt_data[idx].vmt_size == 0) {
+
+    /*
+     * Reject empty or invalid entries.
+     *
+     * Offset 0 is treated as invalid because it would point to the
+     * beginning of the vmount structure instead of mount data.
+     */
+    if (vmt->vmt_data[idx].vmt_off <= 0 ||
+        vmt->vmt_data[idx].vmt_size <= 0)
+    {
         return NULL;
     }
-    
-    /* Validate offset is within vmt_length */
-    if (vmt->vmt_data[idx].vmt_off >= vmt->vmt_length) {
+
+    /*
+     * Convert values once to size_t for consistent arithmetic and
+     * to avoid signed/unsigned comparison issues.
+     */
+    size_t off  = (size_t)vmt->vmt_data[idx].vmt_off;
+    size_t size = (size_t)vmt->vmt_data[idx].vmt_size;
+    size_t len  = (size_t)vmt->vmt_length;
+
+    /*
+     * Ensure the data offset itself lies within the vmount buffer.
+     */
+    if (off >= len) {
         return NULL;
     }
-    
-    /* Overflow-safe size check: ensure size doesn't exceed remaining buffer */
-    if (vmt->vmt_data[idx].vmt_size > vmt->vmt_length - vmt->vmt_data[idx].vmt_off) {
+
+    /*
+     * Overflow-safe bounds validation.
+     *
+     * Validates:
+     *   off + size <= len
+     *
+     * without risking integer overflow.
+     */
+    if (size > len - off) {
         return NULL;
     }
-    
-    return vmt2dataptr(vmt, idx);
+
+    /*
+     * Safe to compute the final pointer.
+     *
+     * The returned pointer references data fully contained within
+     * the vmount structure according to vmt_length.
+     */
+    return (char *)vmt + off;
 }
 
 

--- a/src/os/aix/aix_sigar.c
+++ b/src/os/aix/aix_sigar.c
@@ -1220,7 +1220,7 @@ static inline char *safe_vmt2dataptr(struct vmount *vmt, int idx)
 int sigar_file_system_list_get(sigar_t *sigar,
                                sigar_file_system_list_t *fslist)
 {
-    int i, size, num;
+    int i, j, size, num;
     char *buf, *mntlist, *buf_end;
 
     /* get required size */
@@ -1316,6 +1316,27 @@ int sigar_file_system_list_get(sigar_t *sigar,
         devname = safe_vmt2dataptr(ent, VMT_OBJECT);
         if (devname == NULL) {
             devname = "";
+        }
+
+        /* Skip filesystems with NULL or empty dir_name or devname to prevent JNI crashes */
+        if (dir_name == NULL || *dir_name == '\0' || devname == NULL || *devname == '\0') {
+            fslist->number--;
+            continue;
+        }
+
+        /* Check for duplicate mount points - AIX can report the same mount point multiple times
+         * (e.g., stale NFS mounts). The JNI layer cannot handle duplicates and will crash.
+         * Skip subsequent occurrences of the same mount point. */
+        int is_duplicate = 0;
+        for (j = 0; j < (int)(fslist->number - 1); j++) {
+            if (strcmp(fslist->data[j].dir_name, dir_name) == 0) {
+                is_duplicate = 1;
+                break;
+            }
+        }
+        if (is_duplicate) {
+            fslist->number--;
+            continue;
         }
 
         if (fsp->type == SIGAR_FSTYPE_NETWORK) {


### PR DESCRIPTION
## Problem

Customer experiencing persistent SIGSEGV crashes in Instana agent on AIX when calling `getFileSystemList()`. Multiple javacores show consistent crash pattern:
### Crash Details
```
Location: Java_org_hyperic_sigar_Sigar_getFileSystemListNative[DS]+0x2b0
Signal:   SIGSEGV (Signal 11) - Invalid memory access
Function: getFileSystemListNative() → getFileSystemList()
Systems:  AIX 7.2, AIX 7.3
```

### Stack Trace
```c

3XMTHREADINFO3           Java callstack:
4XESTACKTRACE                at org/hyperic/sigar/Sigar.getFileSystemListNative(Native Method)
4XESTACKTRACE                at org/hyperic/sigar/Sigar.getFileSystemList(Sigar.java:650)
4XESTACKTRACE                at com/instana/agent/host/sensor/impl/filesystem/FileSystemHelper.lambda$readFileSystems$1(FileSystemHelper.java:124)
4XESTACKTRACE                at com/instana/agent/host/sensor/impl/filesystem/FileSystemHelper$$Lambda$836/0x0000000017f54850.apply(Bytecode PC:8)
4XESTACKTRACE                at com/instana/agent/process/handling/sigar/DefaultSigarInstanceUtil.runWithSigar(DefaultSigarInstanceUtil.java:119)
4XESTACKTRACE                at com/instana/agent/host/sensor/impl/filesystem/FileSystemHelper.readFileSystems(FileSystemHelper.java:121)
4XESTACKTRACE                at com/instana/agent/host/sensor/impl/filesystem/FileSystemHelper.collectFileSystemsData(FileSystemHelper.java:274)
4XESTACKTRACE                at com/instana/agent/host/sensor/Host.lambda$activate$4(Host.java:315)
4XESTACKTRACE                at com/instana/agent/host/sensor/Host$$Lambda$889/0x0000000019d866f0.run(Bytecode PC:4)
4XESTACKTRACE                at com/instana/agent/api/ObservableRunnable.run(ObservableRunnable.java:65)
4XESTACKTRACE                at com/instana/agent/util/ErrorLoggingRunnable.run(ErrorLoggingRunnable.java:33(Compiled Code))
4XESTACKTRACE                at com/instana/agent/task/orchestrator/api/ExecutionPipeline.execute(ExecutionPipeline.java:247)
4XESTACKTRACE                at com/instana/agent/task/orchestrator/api/ExecutionPipeline.lambda$wrapWithErrorLogging$5(ExecutionPipeline.java:357)
4XESTACKTRACE                at com/instana/agent/task/orchestrator/api/ExecutionPipeline$$Lambda$329/0x000000001708e750.run(Bytecode PC:8)
4XESTACKTRACE                at com/instana/agent/util/ErrorLoggingRunnable.run(ErrorLoggingRunnable.java:33(Compiled Code))
4XESTACKTRACE                at com/instana/agent/task/orchestrator/impl/ScheduledFutureCallbackTask.run(ScheduledFutureCallbackTask.java:66)
4XESTACKTRACE                at java/util/concurrent/Executors$RunnableAdapter.call(Executors.java:515(Compiled Code))
4XESTACKTRACE                at java/util/concurrent/FutureTask.runAndReset(FutureTask.java:305)
4XESTACKTRACE                at java/util/concurrent/ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305(Compiled Code))
4XESTACKTRACE                at com/instana/agent/task/orchestrator/impl/CallbackDecoratedRunnableScheduledFuture.run(CallbackDecoratedRunnableScheduledFuture.java:53)
4XESTACKTRACE                at java/util/concurrent/ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128(Compiled Code))
4XESTACKTRACE                at java/util/concurrent/ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
4XESTACKTRACE                at io/netty/util/concurrent/FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
4XESTACKTRACE                at java/lang/Thread.run(Thread.java:836)
3XMTHREADINFO3           Native callstack:
4XENATIVESTACK               Java_org_hyperic_sigar_Sigar_getFileSystemListNative[DS]+0x2b0 (0x090000000B7E6784 [libsigar-ppc64-aix-7.so+0x32784])
4XENATIVESTACK               (0x09000000091F983C [libj9vm29.so+0x1b383c])
4XENATIVESTACK               ffi_call+0x110 (0x09000000091F9134 [libj9vm29.so+0x1b3134])
4XENATIVESTACK               (0x0900000009258310 [libj9vm29.so+0x212310])
4XENATIVESTACK               (0x090000000912EF68 [libj9vm29.so+0xe8f68])
4XENATIVESTACK               runJavaThread+0x280 (0x0900000009084E64 [libj9vm29.so+0x3ee64])
4XENATIVESTACK               _ZL23javaProtectedThreadProcP13J9PortLibraryPv+0x120 (0x090000000906BA64 [libj9vm29.so+0x25a64])
4XENATIVESTACK               omrsig_protect+0x4fc (0x0900000009462260 [libj9prt29.so+0x60260])
4XENATIVESTACK               javaThreadProc+0x70 (0x090000000906B8D4 [libj9vm29.so+0x258d4])
4XENATIVESTACK               thread_wrapper+0x14c (0x0900000006635590 [libj9thr29.so+0x5590])
4XENATIVESTACK               (0x0900000000089214 [libpthreads.a+0x214])
NULL
```


## Root Cause

The `vmt2dataptr()` macro directly adds offsets to the vmount pointer without validation:

```c
#define vmt2dataptr(vmt, idx) ((char *)vmt + vmt->vmt_data[idx].vmt_off)
```
When `mntctl()` system call returns corrupted vmount data (typically from **NFS/CIFS network mounts**), the `vmt_data[idx].vmt_off` field can contain invalid values that point beyond the allocated buffer.

### Solution
**1. Enhanced `safe_vmt2dataptr()` function**
- Replaced unsafe `vmt2dataptr()` macro with 6-layer validation wrapper in `src/os/aix/aix_sigar.c`
- Validates NULL pointer, structure size, array index, entry validity, offset bounds, and overflow-safe bounds
- Returns `NULL` safely when vmount descriptors are invalid or corrupted

**2. Buffer safety checks**
- Added validation in main loop to prevent buffer overruns
- Validates vmount header can be read before processing
- Validates `vmt_length` before using it

**3. Duplicate mount point detection**
- Added `contains_mount_point()` helper function
- Checks if mount point already exists in filesystem list before adding
- Handles NULL/empty strings safely
- Enhanced validation in `sigar_file_system_list_get()` with NULL/empty validation and duplicate detection before memory allocation

**4. Optimized memory allocation**
- Moved `SIGAR_FILE_SYSTEM_LIST_GROW` to occur AFTER validation
- Only allocates memory for valid, non-duplicate entries

#### vmount Structure Documentation
```c
Per AIX /usr/include/sys/vmount.h:

#define VMT_OBJECT      0    /* Device name (/dev/hd4) */
#define VMT_STUB        1    /* Mount point (/) */
#define VMT_HOST        2    /* Host (unused) */
#define VMT_HOSTNAME    3    /* Network hostname (NFS server) */
#define VMT_OBJECT_NAME 4    /* Object name (unused) */
#define VMT_ARGS        5    /* Mount options (rw,log=/dev/hd8) */
#define VMT_LASTINDEX   5    /* Last valid index */

struct vmount {
    uint vmt_revision;
    uint vmt_length;        /* Total structure length */
    fsid_t vmt_fsid;
    int vmt_gfstype;
    int vmt_flags;
    int vmt_time;
    vmt_data_t vmt_data[VMT_LASTINDEX + 1];  /* Array size = 6 */
    /* Variable length data follows */
};
```
Most likely crash point: VMT_HOSTNAME (index 3) when processing NFS/CIFS mounts with corrupted metadata.

### Files Changed

- src/os/aix/aix_sigar.c: Enhanced validation in safe_vmt2dataptr() and sigar_file_system_list_get()