### PR TITLE
INSTA-89756 - Fix stale JNI class reference for AIX NFS filesystem enumeration

### DIFF
--- a/bindings/java/src/jni/javasigar.c
+++ b/bindings/java/src/jni/javasigar.c
@@ -445,6 +445,9 @@ JNIEXPORT jobjectArray SIGAR_JNIx(getFileSystemListNative)
         jclass obj_cls;
 
         if (JENV->PushLocalFrame(env, 16) < 0) {
+            if (nfs_cls != NULL) {
+                JENV->DeleteGlobalRef(env, nfs_cls);
+            }
             sigar_file_system_list_destroy(sigar, &fslist);
             return NULL;
         }
@@ -473,6 +476,9 @@ JNIEXPORT jobjectArray SIGAR_JNIx(getFileSystemListNative)
         fsobj = JENV->AllocObject(env, obj_cls);
         if (JENV->ExceptionCheck(env)) {
             JENV->PopLocalFrame(env, NULL);
+            if (nfs_cls != NULL) {
+                JENV->DeleteGlobalRef(env, nfs_cls);
+            }
             sigar_file_system_list_destroy(sigar, &fslist);
             return NULL;
         }
@@ -504,12 +510,18 @@ JNIEXPORT jobjectArray SIGAR_JNIx(getFileSystemListNative)
         JENV->SetObjectArrayElement(env, fsarray, i, fsobj);
         JENV->PopLocalFrame(env, NULL);
         if (JENV->ExceptionCheck(env)) {
+            if (nfs_cls != NULL) {
+                JENV->DeleteGlobalRef(env, nfs_cls);
+            }
             sigar_file_system_list_destroy(sigar, &fslist);
             return NULL;
         }
     }
 
     sigar_file_system_list_destroy(sigar, &fslist);
+    if (nfs_cls != NULL) {
+        JENV->DeleteGlobalRef(env, nfs_cls);
+    }
 
     return fsarray;
 }

--- a/bindings/java/src/jni/javasigar.c
+++ b/bindings/java/src/jni/javasigar.c
@@ -457,7 +457,11 @@ JNIEXPORT jobjectArray SIGAR_JNIx(getFileSystemListNative)
             strstr(fs->dev_name, ":/"))
         {
             if (!nfs_cls) {
-                nfs_cls = SIGAR_FIND_CLASS("NfsFileSystem");
+                jclass local_nfs_cls = SIGAR_FIND_CLASS("NfsFileSystem");
+					if (local_nfs_cls != NULL) {
+						nfs_cls = JENV->NewGlobalRef(env, local_nfs_cls);
+						JENV->DeleteLocalRef(env, local_nfs_cls);
+					}
             }
             obj_cls = nfs_cls;
         }


### PR DESCRIPTION
## Summary
Fixes a native crash on AIX during SIGAR filesystem enumeration when multiple NFS mounts are present.
### Crash Details
```c
Location: Java_org_hyperic_sigar_Sigar_getFileSystemListNative[DS]+0x2b0
Signal:   SIGSEGV (Signal 11) - Invalid memory access
Function: getFileSystemListNative() → getFileSystemList()
Systems:  AIX 7.2, AIX 7.3
```

### Stack Trace
```c

3XMTHREADINFO3           Java callstack:
4XESTACKTRACE                at org/hyperic/sigar/Sigar.getFileSystemListNative(Native Method)
4XESTACKTRACE                at org/hyperic/sigar/Sigar.getFileSystemList(Sigar.java:650)
4XESTACKTRACE                at com/instana/agent/host/sensor/impl/filesystem/FileSystemHelper.lambda$readFileSystems$1(FileSystemHelper.java:124)
4XESTACKTRACE                at com/instana/agent/host/sensor/impl/filesystem/FileSystemHelper$$Lambda$836/0x0000000017f54850.apply(Bytecode PC:8)
4XESTACKTRACE                at com/instana/agent/process/handling/sigar/DefaultSigarInstanceUtil.runWithSigar(DefaultSigarInstanceUtil.java:119)
4XESTACKTRACE                at com/instana/agent/host/sensor/impl/filesystem/FileSystemHelper.readFileSystems(FileSystemHelper.java:121)
4XESTACKTRACE                at com/instana/agent/host/sensor/impl/filesystem/FileSystemHelper.collectFileSystemsData(FileSystemHelper.java:274)
4XESTACKTRACE                at com/instana/agent/host/sensor/Host.lambda$activate$4(Host.java:315)
4XESTACKTRACE                at com/instana/agent/host/sensor/Host$$Lambda$889/0x0000000019d866f0.run(Bytecode PC:4)
4XESTACKTRACE                at com/instana/agent/api/ObservableRunnable.run(ObservableRunnable.java:65)
4XESTACKTRACE                at com/instana/agent/util/ErrorLoggingRunnable.run(ErrorLoggingRunnable.java:33(Compiled Code))
4XESTACKTRACE                at com/instana/agent/task/orchestrator/api/ExecutionPipeline.execute(ExecutionPipeline.java:247)
4XESTACKTRACE                at com/instana/agent/task/orchestrator/api/ExecutionPipeline.lambda$wrapWithErrorLogging$5(ExecutionPipeline.java:357)
4XESTACKTRACE                at com/instana/agent/task/orchestrator/api/ExecutionPipeline$$Lambda$329/0x000000001708e750.run(Bytecode PC:8)
4XESTACKTRACE                at com/instana/agent/util/ErrorLoggingRunnable.run(ErrorLoggingRunnable.java:33(Compiled Code))
4XESTACKTRACE                at com/instana/agent/task/orchestrator/impl/ScheduledFutureCallbackTask.run(ScheduledFutureCallbackTask.java:66)
4XESTACKTRACE                at java/util/concurrent/Executors$RunnableAdapter.call(Executors.java:515(Compiled Code))
4XESTACKTRACE                at java/util/concurrent/FutureTask.runAndReset(FutureTask.java:305)
4XESTACKTRACE                at java/util/concurrent/ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305(Compiled Code))
4XESTACKTRACE                at com/instana/agent/task/orchestrator/impl/CallbackDecoratedRunnableScheduledFuture.run(CallbackDecoratedRunnableScheduledFuture.java:53)
4XESTACKTRACE                at java/util/concurrent/ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128(Compiled Code))
4XESTACKTRACE                at java/util/concurrent/ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
4XESTACKTRACE                at io/netty/util/concurrent/FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
4XESTACKTRACE                at java/lang/Thread.run(Thread.java:836)
3XMTHREADINFO3           Native callstack:
4XENATIVESTACK               Java_org_hyperic_sigar_Sigar_getFileSystemListNative[DS]+0x2b0 (0x090000000B7E6784 [libsigar-ppc64-aix-7.so+0x32784])
4XENATIVESTACK               (0x09000000091F983C [libj9vm29.so+0x1b383c])
4XENATIVESTACK               ffi_call+0x110 (0x09000000091F9134 [libj9vm29.so+0x1b3134])
4XENATIVESTACK               (0x0900000009258310 [libj9vm29.so+0x212310])
4XENATIVESTACK               (0x090000000912EF68 [libj9vm29.so+0xe8f68])
4XENATIVESTACK               runJavaThread+0x280 (0x0900000009084E64 [libj9vm29.so+0x3ee64])
4XENATIVESTACK               _ZL23javaProtectedThreadProcP13J9PortLibraryPv+0x120 (0x090000000906BA64 [libj9vm29.so+0x25a64])
4XENATIVESTACK               omrsig_protect+0x4fc (0x0900000009462260 [libj9prt29.so+0x60260])
4XENATIVESTACK               javaThreadProc+0x70 (0x090000000906B8D4 [libj9vm29.so+0x258d4])
4XENATIVESTACK               thread_wrapper+0x14c (0x0900000006635590 [libj9thr29.so+0x5590])
4XENATIVESTACK               (0x0900000000089214 [libpthreads.a+0x214])
NULL
```

## Root cause
`getFileSystemListNative` cached `NfsFileSystem` using a local JNI class reference created inside a per-iteration local frame. After `PopLocalFrame`, that reference became invalid, but it was reused for the next NFS entry in `AllocObject`, causing a native crash.
For NFS entries, the code lazily resolved `NfsFileSystem` and cached it in `nfs_cls`:

```c
if (!nfs_cls) {
    nfs_cls = SIGAR_FIND_CLASS("NfsFileSystem");
}
obj_cls = nfs_cls;
```
The same method also uses PushLocalFrame() / PopLocalFrame() around each loop iteration.

Because SIGAR_FIND_CLASS("NfsFileSystem") returns a local JNI reference, and that local reference was created inside an iteration frame, it became invalid once PopLocalFrame() was called. On the next NFS entry, the stale class reference was reused in AllocObject(), which caused the crash  on AIX.
In practice the failure pattern was:

- first NFS filesystem entry succeeds
- loop pops the local JNI frame
- cached nfs_cls now points to an invalid local ref
- second NFS filesystem entry reuses that invalid class ref
- AllocObject() crashes the JVM

## Fix
When `NfsFileSystem` is first resolved:
- keep the temporary local ref
- promote it with `NewGlobalRef`
- delete the temporary local ref
- reuse only the global ref for subsequent NFS entries

## Validation
- Reproduced crash on AIX with multiple NFS mounts
- Verified crash occurred on the second NFS filesystem entry
- Applied `NewGlobalRef` fix
- Re-ran with the same mounts and confirmed filesystem enumeration completed successfully without crash